### PR TITLE
Dev/mass/instant from setters

### DIFF
--- a/XamlFlair.UWP/Constants.cs
+++ b/XamlFlair.UWP/Constants.cs
@@ -20,11 +20,11 @@ namespace XamlFlair
 
 			internal static string Translation = "Translation";
 
-			internal static string TranslationX = "Translation.X";
+			internal static string TranslationX = $"{nameof(Translation)}.X";
 
-			internal static string TranslationY = "Translation.Y";
+			internal static string TranslationY = $"{nameof(Translation)}.Y";
 
-			internal static string TranslationZ = "Translation.Z";
+			internal static string TranslationZ = $"{nameof(Translation)}.Z";
 
 			internal static string ScaleX = "Scale.X";
 

--- a/XamlFlair.UWP/Entities/CompositionAnimations.cs
+++ b/XamlFlair.UWP/Entities/CompositionAnimations.cs
@@ -104,13 +104,6 @@ namespace XamlFlair
 
 		internal override void Start(FrameworkElement element, bool isFrom = false)
 		{
-			if (this is TranslateXAnimation || this is TranslateYAnimation)
-			{
-				// The new way of handling translate animations (see Translation property section):
-				// https://blogs.windows.com/buildingapps/2017/06/22/sweet-ui-made-possible-easy-windows-ui-windows-10-creators-update/
-				ElementCompositionPreview.SetIsTranslationEnabled(element, true);
-			}
-
 			_animation = base.StartAnimation<ScalarKeyFrameAnimation>(element,
 				duration =>
 				{

--- a/XamlFlair.UWP/Entities/CompositionAnimations.cs
+++ b/XamlFlair.UWP/Entities/CompositionAnimations.cs
@@ -54,7 +54,7 @@ namespace XamlFlair
 				: Duration;
 
 			_visual.Size = new Vector2((float)_element.ActualWidth, (float)_element.ActualHeight);
-			_visual.CenterPoint = GetTransformCenter();
+			_visual.CenterPoint = _element.GetTransformCenter(Settings);
 
 			return duration;
 		}
@@ -83,14 +83,6 @@ namespace XamlFlair
 			_visual.StartAnimation(TargetProperty, expression);
 
 			return expression;
-		}
-
-		protected Vector3 GetTransformCenter()
-		{
-			var centerX = (float)(_element.ActualWidth * Settings.TransformCenterPoint.X);
-			var centerY = (float)(_element.ActualHeight * Settings.TransformCenterPoint.Y);
-
-			return new Vector3(centerX, centerY, 0f);
 		}
 	}
 

--- a/XamlFlair.UWP/Extensions/AnimationExtensions.cs
+++ b/XamlFlair.UWP/Extensions/AnimationExtensions.cs
@@ -17,10 +17,9 @@ namespace XamlFlair.Extensions
 {
 	internal static class AnimationExtensions
 	{
-		// ---------------------------------------------------------------
-		// TODO: Investigate whether or not we should be specifying values 
-		// for the "z" on Vector3 (ex: visual.Offset.Z instead of 0f)
-		// ---------------------------------------------------------------
+		// ====================
+		// FADE
+		// ====================
 
 		internal static void FadeTo(this FrameworkElement element, AnimationSettings settings, ref AnimationGroup group)
 		{
@@ -37,12 +36,7 @@ namespace XamlFlair.Extensions
 			group.CreateAnimations(element, settings,
 				animGroup =>
 				{
-					animGroup.CreateScalarAnimation<FadeAnimation>(
-						element,
-						settings,
-						to: settings.Opacity,
-						duration: 1,
-						isFrom: true);
+					ElementCompositionPreview.GetElementVisual(element).Opacity = (float)settings.Opacity;
 
 					return animGroup.CreateScalarAnimation<FadeAnimation>(
 						element,
@@ -50,6 +44,10 @@ namespace XamlFlair.Extensions
 						to: 1);
 				});
 		}
+
+		// ====================
+		// TRANSLATE
+		// ====================
 
 		internal static void TranslateXTo(this FrameworkElement element, AnimationSettings settings, ref AnimationGroup group)
 		{
@@ -86,12 +84,17 @@ namespace XamlFlair.Extensions
 			group.CreateAnimations(element, settings,
 				animGroup =>
 				{
-					animGroup.CreateScalarAnimation<TranslateXAnimation>(
-						element,
-						settings,
-						to: (float)settings.OffsetX,
-						duration: 1,
-						isFrom: true);
+					var visual = ElementCompositionPreview.GetElementVisual(element);
+
+					// Since Translation doesn't exist as a property on Visual, we try to fetch it from the PropertySet
+					if (visual.Properties.TryGetVector3(TargetProperties.Translation, out var translation) == CompositionGetValueStatus.Succeeded)
+					{
+						visual.Properties.InsertVector3(TargetProperties.Translation, new Vector3((float)settings.OffsetX, translation.Y, translation.Z));
+					}
+					else
+					{
+						visual.Properties.InsertVector3(TargetProperties.Translation, new Vector3((float)settings.OffsetX, 0f, 0f));
+					}
 
 					return animGroup.CreateScalarAnimation<TranslateXAnimation>(
 						element,
@@ -105,12 +108,17 @@ namespace XamlFlair.Extensions
 			group.CreateAnimations(element, settings,
 				animGroup =>
 				{
-					animGroup.CreateScalarAnimation<TranslateYAnimation>(
-						element,
-						settings,
-						to: (float)settings.OffsetY,
-						duration: 1,
-						isFrom: true);
+					var visual = ElementCompositionPreview.GetElementVisual(element);
+
+					// Since Translation doesn't exist as a property on Visual, we try to fetch it from the PropertySet
+					if (visual.Properties.TryGetVector3(TargetProperties.Translation, out var translation) == CompositionGetValueStatus.Succeeded)
+					{
+						visual.Properties.InsertVector3(TargetProperties.Translation, new Vector3(translation.X, (float)settings.OffsetY, translation.Z));
+					}
+					else
+					{
+						visual.Properties.InsertVector3(TargetProperties.Translation, new Vector3(0f, (float)settings.OffsetY, 0f));
+					}
 
 					return animGroup.CreateScalarAnimation<TranslateYAnimation>(
 						element,
@@ -124,12 +132,17 @@ namespace XamlFlair.Extensions
 			group.CreateAnimations(element, settings,
 				animGroup =>
 				{
-					animGroup.CreateScalarAnimation<TranslateZAnimation>(
-						element,
-						settings,
-						to: (float)settings.OffsetZ,
-						duration: 1,
-						isFrom: true);
+					var visual = ElementCompositionPreview.GetElementVisual(element);
+
+					// Since Translation doesn't exist as a property on Visual, we try to fetch it from the PropertySet
+					if (visual.Properties.TryGetVector3(TargetProperties.Translation, out var translation) == CompositionGetValueStatus.Succeeded)
+					{
+						visual.Properties.InsertVector3(TargetProperties.Translation, new Vector3(translation.X, translation.Y, (float)settings.OffsetZ));
+					}
+					else
+					{
+						visual.Properties.InsertVector3(TargetProperties.Translation, new Vector3(0f, 0f, (float)settings.OffsetZ));
+					}
 
 					return animGroup.CreateScalarAnimation<TranslateZAnimation>(
 						element,
@@ -137,6 +150,10 @@ namespace XamlFlair.Extensions
 						to: 0f);
 				});
 		}
+
+		// ====================
+		// SCALE
+		// ====================
 
 		internal static void ScaleXTo(this FrameworkElement element, AnimationSettings settings, ref AnimationGroup group)
 		{
@@ -173,12 +190,8 @@ namespace XamlFlair.Extensions
 			group.CreateAnimations(element, settings,
 				animGroup =>
 				{
-					animGroup.CreateScalarAnimation<ScaleXAnimation>(
-						element,
-						settings,
-						to: (float)settings.ScaleX,
-						duration: 1,
-						isFrom: true);
+					var visual = ElementCompositionPreview.GetElementVisual(element);
+					visual.Scale = new Vector3((float)settings.ScaleX, visual.Scale.Y, visual.Scale.Z);
 
 					return animGroup.CreateScalarAnimation<ScaleXAnimation>(
 						element,
@@ -192,12 +205,8 @@ namespace XamlFlair.Extensions
 			group.CreateAnimations(element, settings,
 				animGroup =>
 				{
-					animGroup.CreateScalarAnimation<ScaleYAnimation>(
-						element,
-						settings,
-						to: (float)settings.ScaleY,
-						duration: 1,
-						isFrom: true);
+					var visual = ElementCompositionPreview.GetElementVisual(element);
+					visual.Scale = new Vector3(visual.Scale.X, (float)settings.ScaleY, visual.Scale.Z);
 
 					return animGroup.CreateScalarAnimation<ScaleYAnimation>(
 						element,
@@ -211,12 +220,8 @@ namespace XamlFlair.Extensions
 			group.CreateAnimations(element, settings,
 				animGroup =>
 				{
-					animGroup.CreateScalarAnimation<ScaleZAnimation>(
-						element,
-						settings,
-						to: (float)settings.ScaleZ,
-						duration: 1,
-						isFrom: true);
+					var visual = ElementCompositionPreview.GetElementVisual(element);
+					visual.Scale = new Vector3(visual.Scale.X, visual.Scale.Y, (float)settings.ScaleZ);
 
 					return animGroup.CreateScalarAnimation<ScaleZAnimation>(
 						element,
@@ -224,6 +229,10 @@ namespace XamlFlair.Extensions
 						to: 1f);
 				});
 		}
+
+		// ====================
+		// ROTATE
+		// ====================
 
 		internal static void RotateTo(this FrameworkElement element, AnimationSettings settings, ref AnimationGroup group)
 		{
@@ -240,12 +249,7 @@ namespace XamlFlair.Extensions
 			group.CreateAnimations(element, settings,
 				animGroup =>
 				{
-					animGroup.CreateScalarAnimation<RotateAnimation>(
-						element,
-						settings,
-						to: settings.Rotation,
-						duration: 1,
-						isFrom: true);
+					ElementCompositionPreview.GetElementVisual(element).RotationAngleInDegrees = (float)settings.Rotation;
 
 					return animGroup.CreateScalarAnimation<RotateAnimation>(
 						element,
@@ -253,6 +257,10 @@ namespace XamlFlair.Extensions
 						to: 0);
 				});
 		}
+
+		// ====================
+		// BLUR
+		// ====================
 
 		internal static void BlurTo(this FrameworkElement element, AnimationSettings settings, ref AnimationGroup group)
 		{
@@ -283,6 +291,10 @@ namespace XamlFlair.Extensions
 				});
 		}
 
+		// ====================
+		// SATURATE
+		// ====================
+
 		internal static void SaturateTo(this FrameworkElement element, AnimationSettings settings, ref AnimationGroup group)
 		{
 			group.CreateAnimations(element, settings,
@@ -311,6 +323,10 @@ namespace XamlFlair.Extensions
 						to: AnimationSettings.DEFAULT_SATURATION);
 				});
 		}
+
+		// ====================
+		// TINT
+		// ====================
 
 		internal static void TintTo(this FrameworkElement element, AnimationSettings settings, ref AnimationGroup group)
 		{
@@ -341,6 +357,7 @@ namespace XamlFlair.Extensions
 				});
 		}
 
+
 		internal static void ApplyInitialSettings(this FrameworkElement element, AnimationSettings settings)
 		{
 			var group = new AnimationGroup();
@@ -351,7 +368,7 @@ namespace XamlFlair.Extensions
 				visual.Opacity = (float)settings.Opacity;
 			}
 
-			if (settings.OffsetX != 0 || settings.OffsetY != 0)
+			if (settings.OffsetX != 0 || settings.OffsetY != 0 || settings.OffsetZ != 0)
 			{
 				visual.Properties.InsertVector3(TargetProperties.Translation, new Vector3((float)settings.OffsetX, (float)settings.OffsetY, (float)settings.OffsetZ));
 			}

--- a/XamlFlair.UWP/Extensions/ListViewBaseExtensions.cs
+++ b/XamlFlair.UWP/Extensions/ListViewBaseExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Hosting;
 using XamlFlair.UWP.Logging;
 
 namespace XamlFlair.Extensions
@@ -79,7 +80,7 @@ namespace XamlFlair.Extensions
 
 			// LIMITATION: Currently, for proper item animation handling, item animations
 			// MUST include a 'FadeFrom' animation with an Opacity value of 0
-			item.Opacity = 0;
+			ElementCompositionPreview.GetElementVisual(item).Opacity = (float)settings.Opacity;
 
 			if (!isFirstItemContainerLoaded)
 			{
@@ -121,6 +122,10 @@ namespace XamlFlair.Extensions
 
 		private static void AnimateVisibleItem(SelectorItem item, AnimationSettings settings, int index, double interElementDelay)
 		{
+			// The new way of handling translate animations (see Translation property section):
+			// https://blogs.windows.com/buildingapps/2017/06/22/sweet-ui-made-possible-easy-windows-ui-windows-10-creators-update/
+			ElementCompositionPreview.SetIsTranslationEnabled(item, true);
+
 			// Create a clone of 'settings'
 			var itemSettings = new AnimationSettings().ApplyOverrides(settings);
 

--- a/XamlFlair.WPF/Extensions/AnimationExtensions.cs
+++ b/XamlFlair.WPF/Extensions/AnimationExtensions.cs
@@ -19,6 +19,10 @@ namespace XamlFlair.Extensions
 		private const short ROTATE_INDEX = 2;
 		private const short TRANSLATE_INDEX = 3;
 
+		// ====================
+		// FADE
+		// ====================
+
 		internal static Storyboard FadeTo(this FrameworkElement element, AnimationSettings settings, ref Storyboard storyboard)
 		{
 			// TODO: Investigate to determine the use-case of having the need for calling BeginAnimation() in WPF
@@ -46,6 +50,10 @@ namespace XamlFlair.Extensions
 
 			return storyboard;
 		}
+
+		// ====================
+		// TRANSLATE
+		// ====================
 
 		internal static Storyboard TranslateXTo(this FrameworkElement element, AnimationSettings settings, ref Storyboard storyboard)
 		{
@@ -99,6 +107,10 @@ namespace XamlFlair.Extensions
 			return storyboard;
 		}
 
+		// ====================
+		// SCALE
+		// ====================
+
 		internal static Storyboard ScaleXTo(this FrameworkElement element, AnimationSettings settings, ref Storyboard storyboard)
 		{
 			var transform = (element.RenderTransform as TransformGroup) ?? CreateTransformGroup();
@@ -151,6 +163,10 @@ namespace XamlFlair.Extensions
 			return storyboard;
 		}
 
+		// ====================
+		// ROTATE
+		// ====================
+
 		internal static Storyboard RotateTo(this FrameworkElement element, AnimationSettings settings, ref Storyboard storyboard)
 		{
 			var transform = (element.RenderTransform as TransformGroup) ?? CreateTransformGroup();
@@ -176,6 +192,10 @@ namespace XamlFlair.Extensions
 
 			return storyboard;
 		}
+
+		// ====================
+		// BLUR
+		// ====================
 
 		internal static Storyboard BlurTo(this FrameworkElement element, AnimationSettings settings, ref Storyboard storyboard)
 		{


### PR DESCRIPTION
 Replaced UWP 1-millisecond "from" animations with setting values directly on the related properties (except effects) + minor fixes